### PR TITLE
fixed server.js file path to 'public'

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,9 +6,9 @@ const path = require('path'); // File path utilities
 const app = express(); // create Express instance
 const PORT = 3000;
 const URL = 'http://localhost:' + PORT;
-const PAGES_DIR = path.join(__dirname, 'src/pages');
+const PAGES_DIR = path.join(__dirname, 'public/pages');
 
-app.use(express.static('src')); // Work only with files in 'src'
+app.use(express.static('public')); // Work only with files in 'public'
 
 /* ------------------------------------------- Routes ------------------------------------------- */
 


### PR DESCRIPTION
It is as the title says. server.js originally looked for files in a directory named "src," which had been renamed to "public" in a previous commit (ab9edf6ee00a0e6dc7c865ffe506f916df157ca5).